### PR TITLE
Allow filename to be set

### DIFF
--- a/lib/rightsignature/document.rb
+++ b/lib/rightsignature/document.rb
@@ -197,7 +197,7 @@ module RightSignature
     #   @rs_connection.send_document_from_url("http://myfile/here", 'My Subject', recipients, options)
     #
     def send_document_from_url(url, subject, recipients, options={})
-      send_document(subject, recipients, {:type => "url", :filename => File.basename(url), :value => url }, options)
+      send_document(subject, recipients, {:type => "url", :filename => (options[:filename] or File.basename(url)), :value => url }, options)
     end
     
     # Creates a document from a base64 encoded file or publicly available URL


### PR DESCRIPTION
in send_document_from_url.
the default just uses everything after teh last / which can include auth parameters, which are undesired in a filename.
