### PR TITLE
fix error in documentation for send_as_embedded_signers

### DIFF
--- a/lib/rightsignature/template.rb
+++ b/lib/rightsignature/template.rb
@@ -248,7 +248,6 @@ module RightSignature
     # Ex. call with all options used
     #   @rs_connection.send_as_embedded_signers(
     #     "a_1_zcfdidf8fi23", 
-    #     "Your Employee Handbook", 
     #     [{"employee" => {:name => "John Employee", :email => "john@employee.com"}}],
     #     {
     #       :description => "Please read over the handbook and sign it.",


### PR DESCRIPTION
The docs were using a parameter in the example call that the method doesn't accept. I've removed it.